### PR TITLE
Split the Section container into sub-components

### DIFF
--- a/src/app/components/atoms/container-frame/ContainerFrame.tsx
+++ b/src/app/components/atoms/container-frame/ContainerFrame.tsx
@@ -1,0 +1,16 @@
+import { TemplateFormat } from "@components/molecules/sectionContainer/SectionContainer";
+
+
+export default function ContainerFrame({templateFormat, children}: {templateFormat?: TemplateFormat, children: React.ReactNode}) {
+    const wrapperStyles = 'h-full ml-5 mr-5 mt-16 mb-14 sm:ml-16 sm:mr-16 md:ml-8 md:mr-8 lg:ml-4 lg:mr-4 xl:w-7xl';
+    const wrapper = templateFormat === TemplateFormat.LATEST || TemplateFormat.WHY || undefined ? wrapperStyles : '';
+    const bgColorAndzIndex = templateFormat === TemplateFormat.WHY ? 'bg-gray-100' : 'bg-zinc-50';
+
+    return(
+        <div className={`flex w-full min-h-[660px] text-center justify-center xl:text-left ${bgColorAndzIndex}`}>
+            <div className={wrapper}>
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/src/app/components/atoms/container-template/ContainerTemplate.tsx
+++ b/src/app/components/atoms/container-template/ContainerTemplate.tsx
@@ -1,0 +1,17 @@
+import { ContainerType, TemplateFormat } from "@components/molecules/sectionContainer/SectionContainer";
+
+
+export default function ContainerTemplate({templateFormat, children, title, subtitle}: ContainerType) {
+    const titleStyles = templateFormat === TemplateFormat.HERO ? 'text-6xl font-bold' : 'text-3xl font-light';
+    return(
+        <>
+            <div className="xl:w-2/3">
+                <p className={`text-[hsl(233,26%,24%)] mb-6 ${titleStyles}`}>{title}</p>
+                {subtitle && (<p className="text-[hsl(233,8%,62%)] text-xl xl:max-w-lg">{subtitle}</p>)}
+            </div>
+            <div className="mt-16 w-full sm:flex sm:flex-wrap sm:justify-between md:justify-around xl:justify-between">
+                {children}
+            </div>
+        </>
+    )
+}

--- a/src/app/components/molecules/sectionContainer/SectionContainer.stories.tsx
+++ b/src/app/components/molecules/sectionContainer/SectionContainer.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/nextjs/*";
-import SectionContainer, { ContainerFormat } from "./SectionContainer";
+import SectionContainer, { TemplateFormat } from "./SectionContainer";
 
 const meta = {
     title: 'Molecule/Section Container',
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof SectionContainer>;
 
 export const StandardContainer: Story = {
     args: {
-        containerFormat: ContainerFormat.LATEST,
+        templateFormat: TemplateFormat.LATEST,
         title: 'Test Title',
     },
     render: (args) => {
@@ -26,7 +26,7 @@ export const StandardContainer: Story = {
 
 export const SectionSubtitleContainer: Story = {
     args: {
-        containerFormat: ContainerFormat.LATEST,
+        templateFormat: TemplateFormat.LATEST,
         title: 'Test Title',
         subtitle: 'Here is a subtitle for the container'
     },

--- a/src/app/components/molecules/sectionContainer/SectionContainer.tsx
+++ b/src/app/components/molecules/sectionContainer/SectionContainer.tsx
@@ -1,36 +1,30 @@
+import ContainerFrame from "@components/atoms/container-frame/ContainerFrame";
+import ContainerTemplate from "@components/atoms/container-template/ContainerTemplate";
 import React from "react";
 
-export enum ContainerFormat {
+export enum TemplateFormat {
     HERO,
     WHY,
     LATEST
 }
 
 export type ContainerType = {
-    containerFormat?: ContainerFormat,
+    templateFormat?: TemplateFormat,
     title: string,
     subtitle?: string,
     children: React.ReactNode
 }
 
-export default function SectionContainer({containerFormat, children, title, subtitle}: ContainerType) {
-    const wrapperStyles = 'h-full ml-5 mr-5 mt-16 mb-14 sm:ml-16 sm:mr-16 md:ml-8 md:mr-8 lg:ml-4 lg:mr-4 xl:w-7xl';
-    const wrapper = containerFormat === ContainerFormat.LATEST || ContainerFormat.WHY || undefined ? wrapperStyles : '';
-    
-    const bgColorAndzIndex = containerFormat === ContainerFormat.WHY ? 'bg-gray-100' : 'bg-zinc-50';
-    const titleStyles = containerFormat === ContainerFormat.HERO ? 'text-6xl font-bold' : 'text-3xl font-light';
-
+export default function SectionContainer({templateFormat, title, subtitle, children}: ContainerType) {
     return(
-        <div className={`flex w-full min-h-[660px] text-center justify-center xl:text-left ${bgColorAndzIndex}`}>
-            <div className={wrapper}>
-                <div className="xl:w-2/3">
-                    <p className={`text-[hsl(233,26%,24%)] mb-6 ${titleStyles}`}>{title}</p>
-                    {subtitle && (<p className="text-[hsl(233,8%,62%)] text-xl xl:max-w-lg">{subtitle}</p>)}
-                </div>
-                <div className="mt-16 w-full sm:flex sm:flex-wrap sm:justify-between md:justify-around xl:justify-between">
-                    {children}
-                </div>
-            </div>
-        </div>
+        <ContainerFrame templateFormat={templateFormat}>
+            <ContainerTemplate 
+                templateFormat={templateFormat} 
+                title={title}
+                subtitle={subtitle}
+            >
+                {children}
+            </ContainerTemplate>
+        </ContainerFrame>
     )
 }

--- a/src/app/components/organisms/latest-section/LatestArticlesOrg.tsx
+++ b/src/app/components/organisms/latest-section/LatestArticlesOrg.tsx
@@ -1,12 +1,12 @@
 import Card, { CardFormat } from '@components/atoms/card/Card';
 
 import { blogContent } from '@components/atoms/card/CardContent';
-import SectionContainer, { ContainerFormat } from '@components/molecules/sectionContainer/SectionContainer';
+import SectionContainer, { TemplateFormat } from '@components/molecules/sectionContainer/SectionContainer';
 
 export default function LatestSection() {
     return(
         <SectionContainer 
-            containerFormat={ContainerFormat.LATEST}
+            templateFormat={TemplateFormat.LATEST}
             title={'Latest Articles' }
         >
             {blogContent.map((item, key) => (

--- a/src/app/components/organisms/why-section/WhySectionOrg.tsx
+++ b/src/app/components/organisms/why-section/WhySectionOrg.tsx
@@ -1,13 +1,13 @@
 import { infoContent } from '@components/atoms/card/CardContent';
 import Card, { CardFormat } from '@components/atoms/card/Card';
-import SectionContainer, { ContainerFormat } from '@components/molecules/sectionContainer/SectionContainer';
+import SectionContainer, { TemplateFormat } from '@components/molecules/sectionContainer/SectionContainer';
 
 export default function WhySection() {
     let subtext = 'We leverage Open Banking to turn your bank account into your financial hub. Control your finances like never before.';
     
     return(
         <SectionContainer 
-            containerFormat={ContainerFormat.WHY} 
+            templateFormat={TemplateFormat.WHY} 
             title={'Why choose Easybank?'} 
             subtitle={subtext}           
         >


### PR DESCRIPTION
## What
We have split up the Section container into more components so that it can be used more effectively within the project itself.

## Why
The Hero Section needs to be able to use the SectionContainer uniquely; as such, we would need to split up the container into separate components that can be called upon where necessary. This allows us to maintain the Section containers functionality for the 'Why' and 'Latest' sections, retain their responsive design rules, and also utilise the separate sections of the container where necessary for the Hero Section itself.