### PR TITLE
refactor: revised navbar container widths

### DIFF
--- a/src/app/components/molecules/collapsible-navbar/NavBar.tsx
+++ b/src/app/components/molecules/collapsible-navbar/NavBar.tsx
@@ -18,27 +18,29 @@ export default function Navbar() {
     const navBarRef = useRef(null);
 
     return(
-        <div ref={navBarRef} className="flex w-full h-20 z-[3] bg-white">
-            <div className="flex w-1/4 ml-4 content-center flex-wrap text-center justify-center">
-                <Image 
-                    src={logo}
-                    alt="logo"
-                />
+        <div ref={navBarRef} className="w-full h-20 z-[3] bg-white">
+            <div className="flex h-full m-auto sm:w-[580px] md:flex md:w-2xl lg:w-4xl xl:w-6xl">
+                <div className="flex w-1/4 ml-4 content-center flex-wrap text-center justify-center lg:justify-start md:ml-0">
+                    <Image 
+                        src={logo}
+                        alt="logo"
+                    />
+                </div>
+                {/* If we are at mobile size 768px*/}
+                {!matches && (
+                    <SmallMenu menuStrings={menuElements} navBarRef={navBarRef}/>
+                )}
+                
+                {/* If media is >= 769px */}
+                {matches && (
+                    <>
+                        <LargeMenu menuStrings={menuElements} />
+                        <div className="flex w-1/4 align-center content-center flex-wrap text-center justify-center pr-14 lg:pr-0 lg:justify-end">
+                            <InviteButton />
+                        </div>
+                    </>
+                )}
             </div>
-            {/* If we are at mobile size 768px*/}
-            {!matches && (
-                <SmallMenu menuStrings={menuElements} navBarRef={navBarRef}/>
-            )}
-            
-            {/* If media is >= 769px */}
-            {matches && (
-                <>
-                    <LargeMenu menuStrings={menuElements} />
-                    <div className="flex w-1/4 align-center content-center flex-wrap text-center justify-center pr-14">
-                        <InviteButton />
-                    </div>
-                </>
-            )}
         </div>
     )
 }


### PR DESCRIPTION
## What

The navbar did not resize to take in the container widths that resize according the the responsive behaviors set in other sections of the webpage, this change implements media breakpoints that are used elsewhere so that the behavior is consistent.